### PR TITLE
Bug/89 blog page missing the label of form input

### DIFF
--- a/__tests__/blog.test.tsx
+++ b/__tests__/blog.test.tsx
@@ -116,7 +116,6 @@ describe("Blog Page", () => {
     expect(subscriptionContent).toBeInTheDocument();
     expect(subscriptionInput).toBeInTheDocument();
     expect(subscriptionInput).toHaveAttribute("type", "email");
-    expect(subscriptionInput).toHaveAttribute("value", "YOUR EMAIL");
     expect(subscriptionButton).toBeInTheDocument();
   });
 });

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -64,14 +64,14 @@ describe("Home", () => {
 
   it("should render how we work title in sucess", () => {
     const howWeWorkTitle = screen.getByRole("heading", {
-      name: /We help our clients succeed with innovative strategies./i,
+      name: /we help our clients\nsucceed with innovative\nstrategies\./i,
     });
     expect(howWeWorkTitle).toBeInTheDocument();
   });
 
   it("should render how we work icon in sucess", () => {
     const howWeWorkIcon = screen.getByRole("img", {
-      name: /we help our clients succeed with innovative strategies\.icon/i,
+      name: /we help our clients\nsucceed with innovative\nstrategies\.icon/i,
     });
     expect(howWeWorkIcon).toBeInTheDocument();
     expect(howWeWorkIcon).toHaveAttribute("src", "/images/star.svg");
@@ -153,7 +153,7 @@ describe("Home", () => {
 
   it("should render icon in contact section success", () => {
     const contactIcon = screen.getByRole("img", {
-      name: /let’s bring your tech to the next levelicon/i,
+      name: /let’s bring your\ntech to the next\nlevelicon/i,
     });
     expect(contactIcon).toBeInTheDocument();
     expect(contactIcon).toHaveAttribute("src", "/images/design_icon.svg");

--- a/__tests__/studio.test.jsx
+++ b/__tests__/studio.test.jsx
@@ -55,7 +55,7 @@ describe("Studio Page", () => {
 
   it("should render icon in contact section success", () => {
     const contactIcon = screen.getByRole("img", {
-      name: /let’s bring your tech to the next levelicon/i,
+      name: /let’s bring your\ntech to the next\nlevelicon/i,
     });
     expect(contactIcon).toBeInTheDocument();
     expect(contactIcon).toHaveAttribute("src", "/images/design_icon.svg");

--- a/components/general/Contact.tsx
+++ b/components/general/Contact.tsx
@@ -4,7 +4,7 @@ const Contact = () => {
   return (
     <InfoBlock
       sectionName="Contact"
-      title="Let’s bring your tech to the next level"
+      title={"Let’s bring your\ntech to the next\nlevel"}
       iconPath="/images/design_icon.svg"
       blockType="normal"
       content="Contact us to explore partnership opportunities and discover how we can work together to drive innovation and create positive change."

--- a/components/general/HowWeWork.tsx
+++ b/components/general/HowWeWork.tsx
@@ -4,7 +4,7 @@ const HowWeWork = () => {
   return (
     <InfoBlock
       sectionName="How we work"
-      title="We help our clients succeed with innovative strategies."
+      title={"We help our clients\nsucceed with innovative\nstrategies."}
       iconPath="/images/star.svg"
       blockType="smallHeading"
       content="Our team of experts is dedicated to delivering real results through creativity, strategic

--- a/components/general/InfoBlock/InfoBlock.module.css
+++ b/components/general/InfoBlock/InfoBlock.module.css
@@ -94,14 +94,17 @@
   outline: none;
 }
 
-.info_block__sign_up_content__form__group label {
+.info_block__sign_up_content__form__group span {
   position: absolute;
-
+  left: 0px;
+  top: 0px;
   cursor: text;
+  pointer-events: none;
+  text-transform: uppercase;
   transition: 0.3s ease-in-out;
 }
 
-.info_block__sign_up_content__form__group input:focus label {
-  top: -25px;
+.info_block__sign_up_content__form__group input:focus ~ span {
+  transform: translateY(-25px);
   pointer-events: none;
 }

--- a/components/general/InfoBlock/InfoBlock.module.css
+++ b/components/general/InfoBlock/InfoBlock.module.css
@@ -59,7 +59,7 @@
 .info_block__sign_up_content {
   display: flex;
   flex-direction: column;
-  align-content: space-between;
+  justify-content: space-between;
   grid-column: 3;
   height: 571px;
   padding-left: 48px;
@@ -68,29 +68,40 @@
 .info_block__sign_up_content__text {
   color: var(--text-default);
   margin: 0 0 48px 0;
-  height: 488px;
 }
 
 .info_block__sign_up_content__form {
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
   gap: 20px;
 }
 
 .info_block__sign_up_content__form__group {
-  display: flex;
-  flex-direction: column;
-  width: 75%;
-}
-
-.info_block__sign_up_content__form__input {
-  border: 0;
-  background: transparent;
+  width: 70%;
+  position: relative;
   border-bottom: 1px solid var(--border-default);
 }
 
-.info_block__sign_up_content__form__input:focus {
+.info_block__sign_up_content__form__group input {
+  width: 100%;
+  position: relative;
+  border: 0;
+  background: transparent;
+  transition: 0.3s ease-in-out;
+}
+
+.info_block__sign_up_content__form__group input:focus {
   outline: none;
-  border-bottom: 2px solid #555;
+}
+
+.info_block__sign_up_content__form__group label {
+  position: absolute;
+
+  cursor: text;
+  transition: 0.3s ease-in-out;
+}
+
+.info_block__sign_up_content__form__group input:focus label {
+  top: -25px;
+  pointer-events: none;
 }

--- a/components/general/InfoBlock/InfoBlock.module.css
+++ b/components/general/InfoBlock/InfoBlock.module.css
@@ -104,7 +104,7 @@
   transition: 0.3s ease-in-out;
 }
 
-.info_block__sign_up_content__form__group input:focus ~ span {
+.info_block__sign_up_content__form__group input:focus + span {
   transform: translateY(-25px);
   pointer-events: none;
 }

--- a/components/general/InfoBlock/InfoBlock.module.css
+++ b/components/general/InfoBlock/InfoBlock.module.css
@@ -74,11 +74,17 @@
 .info_block__sign_up_content__form {
   display: flex;
   flex-direction: row;
+  align-items: flex-end;
   gap: 20px;
 }
 
-.info_block__sign_up_content__form__input {
+.info_block__sign_up_content__form__group {
+  display: flex;
+  flex-direction: column;
   width: 75%;
+}
+
+.info_block__sign_up_content__form__input {
   border: 0;
   background: transparent;
   border-bottom: 1px solid var(--border-default);

--- a/components/general/InfoBlock/InfoBlock.tsx
+++ b/components/general/InfoBlock/InfoBlock.tsx
@@ -1,4 +1,4 @@
-import styles from "@/styles/InfoBlock.module.css";
+import styles from "./InfoBlock.module.css";
 import { fontSyne, fontSatoshi, fontRobotoMono } from "@/pages/_app";
 import Button from "../../base/Button";
 
@@ -56,11 +56,15 @@ const InfoBlock = ({
             {content}
           </p>
           <form className={styles.info_block__sign_up_content__form}>
-            <input
-              type="email"
-              defaultValue="YOUR EMAIL"
-              className={`global__heading-h4 ${fontSyne.className} ${styles.info_block__sign_up_content__form__input}`}
-            />
+            <div className={styles.info_block__sign_up_content__form__group}>
+              <label htmlFor="email" className={`global__heading-h4 ${fontSyne.className}`}>
+                YOUR EMAIL
+              </label>
+              <input
+                type="email"
+                className={`global__heading-h4 ${fontSyne.className} ${styles.info_block__sign_up_content__form__input}`}
+              />
+            </div>
             <Button>sign up</Button>
           </form>
         </div>

--- a/components/general/InfoBlock/InfoBlock.tsx
+++ b/components/general/InfoBlock/InfoBlock.tsx
@@ -60,10 +60,7 @@ const InfoBlock = ({
               <label htmlFor="email" className={`global__heading-h4 ${fontSyne.className}`}>
                 YOUR EMAIL
               </label>
-              <input
-                type="email"
-                className={`global__heading-h4 ${fontSyne.className} ${styles.info_block__sign_up_content__form__input}`}
-              />
+              <input type="email" className={`global__heading-h4 ${fontSyne.className}`} />
             </div>
             <Button>sign up</Button>
           </form>

--- a/components/general/InfoBlock/InfoBlock.tsx
+++ b/components/general/InfoBlock/InfoBlock.tsx
@@ -57,10 +57,8 @@ const InfoBlock = ({
           </p>
           <form className={styles.info_block__sign_up_content__form}>
             <div className={styles.info_block__sign_up_content__form__group}>
-              <label htmlFor="email" className={`global__heading-h4 ${fontSyne.className}`}>
-                YOUR EMAIL
-              </label>
               <input type="email" className={`global__heading-h4 ${fontSyne.className}`} />
+              <span className={`global__heading-h4 ${fontSyne.className}`}>your email</span>
             </div>
             <Button>sign up</Button>
           </form>

--- a/styles/InfoBlock.module.css
+++ b/styles/InfoBlock.module.css
@@ -8,6 +8,7 @@
 
 .info_block__title {
   grid-column: 1/3;
+  white-space: pre-wrap;
 }
 
 .info_block_heading {


### PR DESCRIPTION
### Descriptions
1. Added label for input in subscription section
2. Adjusted InfoBlock css for text line breaks

- Link to Zenhub Card: https://app.zenhub.com/workspaces/taodemy-63c3dec267d0df73ca6087cb/issues/gh/taodemy/website/89
- Link to UI design (if possible): no need

### Provide screenshots or videos that the function is working.
![image](https://user-images.githubusercontent.com/73293255/222365808-2752a4a1-f7af-4398-bf54-03bf0692da40.png)
![image](https://user-images.githubusercontent.com/73293255/222365943-6e1b68ae-5171-44a6-a45a-16daac8fb712.png)
![image](https://user-images.githubusercontent.com/73293255/222366060-71dfe8f3-1a6e-4246-982c-c34b8e1af386.png)

### Provide screenshots of no warning, or error in the console.
![image](https://user-images.githubusercontent.com/73293255/222366107-cfee572d-5547-4fef-8b06-eff7a337ff2a.png)

- [x] All unit tests passing and coverage of testing is more than 90% unless special needs.
- [x] No merge conflict with the `main` branch, make sure your code is up to date with `main`.
- [x] Check PR title is aligned with your ticket.
- [x] Check your app will run without crashes.
- [x] Check if there are hard-coded values.
- [x] No `//eslint-disable-next-line no-unused-vars`, unless otherwise specified.
- [x] Check you are using `camelCase && PascalCase` correctly.
- [x] Remove unused comments.
