### PR TITLE
fix the card image outflow probs and clean the code

### DIFF
--- a/__tests__/service.test.tsx
+++ b/__tests__/service.test.tsx
@@ -46,5 +46,4 @@ describe("Service", () => {
     });
     expect(servicesTitleContentButton).toBeInTheDocument();
   });
-
 });

--- a/components/ServicePage/ServicesItem.tsx
+++ b/components/ServicePage/ServicesItem.tsx
@@ -31,7 +31,7 @@ const ServiceItem = ({
   service_heading,
   service_info1,
   service_info2,
-  service_name
+  service_name,
 }: serviceItemProps) => {
   return (
     <section className={styles.service}>

--- a/pages/services.tsx
+++ b/pages/services.tsx
@@ -6,11 +6,11 @@ import Services from "@/components/ServicePage/Services";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import EViewPortQuery from "@/constants/viewPortSize";
 
-const {PHONE } = EViewPortQuery;
+const { PHONE } = EViewPortQuery;
 
 export default function Service() {
   const isPhoneSize = useMediaQuery(PHONE);
-  
+
   return (
     <>
       <Head>

--- a/styles/Card.module.css
+++ b/styles/Card.module.css
@@ -49,23 +49,14 @@
   color: inherit;
 }
 
-@media screen and (max-width: 1023px) {
-  .card__image_large,
-  .card__image_medium,
-  .card__image_small {
-  }
-}
-
 @media screen and (max-width: 743px) {
+  .card__image {
+    width: 100%;
+    height: 350px;
+  }
+
   .card__image_large {
     width: 100%;
     min-height: 400px;
-  }
-}
-
-@media screen and (max-width: 743px) {
-  .card__image {
-    width: auto;
-    height: 350px;
   }
 }

--- a/styles/ServicesItem.module.css
+++ b/styles/ServicesItem.module.css
@@ -8,7 +8,7 @@
   display: flex;
   flex-direction: column;
   width: 33%;
-  margin:63px 0;
+  margin: 63px 0;
 }
 
 .service_left_logo {
@@ -40,7 +40,7 @@
   width: 66%;
   flex-direction: column;
   border-left: 1px solid var(--border-default);
-  margin:63px 0;
+  margin: 63px 0;
   padding-left: 48px;
 }
 

--- a/styles/ServicesTitle.module.css
+++ b/styles/ServicesTitle.module.css
@@ -1,5 +1,5 @@
 .service_title {
-  padding:63px 0;
+  padding: 63px 0;
   border-bottom: 1px solid var(--border-default);
 }
 .service_title__heading {


### PR DESCRIPTION
### Descriptions
I fixed the image overflow problem under 744 width, you can test with it. In addition, I make the card css file cleaner.

### Provide screenshots or videos that the function is working.
<img width="577" alt="image" src="https://user-images.githubusercontent.com/70834897/226894749-cb0c67a0-d47f-4a90-9906-340ee6e51aa9.png">

### Provide screenshots of no warning, or error in the console.
<img width="551" alt="image" src="https://user-images.githubusercontent.com/70834897/226894831-200fe4e4-1163-4cf4-93ca-4520931fd9d1.png">

- [x] All unit tests passing and coverage of testing is more than 90% unless special needs.
- [x] No merge conflict with the `main` branch, make sure your code is up to date with `main`.
- [x] Check PR title is aligned with your ticket.
- [x] Check your app will run without crashes.
- [x] Check if there are hard-coded values.
- [x] No `//eslint-disable-next-line no-unused-vars`, unless otherwise specified.
- [x] Check you are using `camelCase && PascalCase` correctly.
- [x] Remove unused comments.
